### PR TITLE
Run notification permission grant handler on the main thread

### DIFF
--- a/Classes/AppDelegate.swift
+++ b/Classes/AppDelegate.swift
@@ -51,7 +51,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
 	
 	func requestPushNotificationsPerms(handler: (() -> Void)? = nil) {
 		Robin.settings.requestAuthorization(forOptions: [.alert, .badge, .sound]) { _, _ in
-			handler?()
+			DispatchQueue.main.async {
+				handler?()
+			}
 		}
 	}
     


### PR DESCRIPTION
Resolves #12. For context of the stack trace leading up to this crash that tipped me off to this fix, I have updated the issue.