### PR TITLE
- Fixed Navigation Bar Bug

### DIFF
--- a/Classes/BaseViewController.swift
+++ b/Classes/BaseViewController.swift
@@ -29,7 +29,16 @@ class BaseViewController: UIViewController {
     
     func setupNavigationBar() {
         self.navigationController?.navigationBar.barStyle = .black;
-        self.navigationController?.navigationBar.barTintColor = Utils().getCurrentThemeColor()
+//        self.navigationController?.navigationBar.barTintColor = Utils().getCurrentThemeColor()
+//        self.navigationController?.view.backgroundColor = Utils().getCurrentThemeColor()
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = Utils().getCurrentThemeColor()
+        self.navigationController?.navigationBar.standardAppearance = appearance;
+        self.navigationController?.navigationBar.scrollEdgeAppearance = self.navigationController?.navigationBar.standardAppearance
+
+        
         self.navigationController?.navigationBar.tintColor = UIColor.white
         self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]
         self.navigationController?.navigationBar.isTranslucent = false

--- a/Classes/Tasks/TasksViewController.swift
+++ b/Classes/Tasks/TasksViewController.swift
@@ -67,8 +67,16 @@ class TasksViewController: BaseViewController {
 			}
 		}
 		self.searchController.searchBar.tintColor = UIColor.white
-        self.searchController.searchBar.barTintColor = Utils().getCurrentThemeColor()
-		
+//        self.searchController.searchBar.barTintColor = Utils().getCurrentThemeColor()
+//        self.navigationController?.view.backgroundColor = Utils().getCurrentThemeColor()
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = Utils().getCurrentThemeColor()
+        self.navigationController?.navigationBar.standardAppearance = appearance;
+        self.navigationController?.navigationBar.scrollEdgeAppearance = self.navigationController?.navigationBar.standardAppearance
+
+
         self.definesPresentationContext = true
         
         self.tableView.estimatedRowHeight = 60


### PR DESCRIPTION
Replaced  ```self.navigationController?.navigationBar.barTintColor = Utils().getCurrentThemeColor()``` with 
```
let appearance = UINavigationBarAppearance()
        appearance.configureWithOpaqueBackground()
        appearance.backgroundColor = Utils().getCurrentThemeColor()
        self.navigationController?.navigationBar.standardAppearance = appearance;
        self.navigationController?.navigationBar.scrollEdgeAppearance = self.navigationController?.navigationBar.standardAppearance
```